### PR TITLE
feat(lib): use argv if config not found

### DIFF
--- a/lib/esnext-coverage.js
+++ b/lib/esnext-coverage.js
@@ -7,14 +7,37 @@ var extendBabelConfig = require('./extend-babel-config');
 var formatterHelper = require('./formatter-helper');
 
 var babelConfig = findConfig('babel');
-var esnextcoverageConfig = findConfig('esnextcoverage');
+var esnextcoverageConfig = findConfig('esnextcoverage') || {};
 
-babelRegister(extendBabelConfig(babelConfig, {
-  only: esnextcoverageConfig.only
-}));
+if (!esnextcoverageConfig.only && !esnextcoverageConfig.ignore) {
+  // Before: ['/path/to/test-framework', '-r', 'esnext-coverage', 'test/foo.js', 'test/bar.js']
+  // After: ['test/foo.js', 'test/bar.js']
+  esnextcoverageConfig.ignore = process.argv.slice(
+    process.argv.indexOf('esnext-coverage') + 1
+  );
+  // If using a default glob, like so: ['/path/to/test-framework', '-r', 'esnext-coverage']
+  if (esnextcoverageConfig.ignore.length === 0) {
+    // Then we use mocha's defaults: ['test/*.js']
+    esnextcoverageConfig.ignore.push('test/*.js');
+  }
+}
+
+function cleanupConfig(config) {
+  var cleanConfig = Object.assign({}, config);
+  delete cleanConfig.reporters;
+  delete cleanConfig.thresholds;
+  return cleanConfig;
+}
+
+babelRegister(extendBabelConfig(babelConfig, cleanupConfig(esnextcoverageConfig)));
 
 process.once('exit', function () {
-  var reporters = esnextcoverageConfig.reporters || [{outFile: 'coverage/coverage.json'}];
+  var reporters = esnextcoverageConfig.reporters || [
+    {
+      formatter: JSON.stringify,
+      outFile: 'reports/coverage/coverage.json'
+    }
+  ];
 
   if (typeof __coverage__ !== 'object') {
     console.error('Failed to generate coverage.');


### PR DESCRIPTION
This allows the user to run commands like `mocha -r esnext-coverage` or `mocha -r esnext-coverage tests/*.js` without specifying the esnext-coverage configuration. The configuration parameters are set to default (JSON-formatted sting saved to reports/coverage/coverage.json).

Related to #1