### PR TITLE
feat(cli/collect): rewrite to work with other actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Usage: esnext-coverage [options] [command]
 Commands:
 
   instrument [options] [file]  instruments code
-  collect [options] [files]
+  collect [options] [file]     collects coverage data
   format [options] [file]      formats coverage data
 
 Options:
@@ -157,8 +157,7 @@ Reads code from stdin or from a file, instruments it, and writes the instrumente
 
 ### [`collect`](docs/collect.md)
 
-Runs instrumented files, collects and outputs code coverage data.  
-:warning: `collect` API is a work in progress.
+Reads code from stdin or from a file, collects coverage data, and writes the result to stdout or to a file.
 
 ### [`format`](docs/format.md)
 

--- a/bin/esnext-coverage
+++ b/bin/esnext-coverage
@@ -18,11 +18,15 @@ program
   .action(require('../lib/actions/instrument'))
   .on('--help', require('../lib/help/instrument'));
 
+//
+// collect
+// --------------------
 program
-  .command('collect [files]')
-  .option('-f --format [formatter]', 'Format the result')
+  .command('collect [file]')
+  .description('collects coverage from instrumented code')
   .option('-o --out-file [file]', 'Write the result to a file')
-  .action(require('../lib/actions/collect'));
+  .action(require('../lib/actions/collect'))
+  .on('--help', require('../lib/help/collect'));
 
 //
 // format

--- a/lib/actions/collect.js
+++ b/lib/actions/collect.js
@@ -1,41 +1,42 @@
 'use strict';
 
 /**
- * A `collect` command to run instrumented code and output code coverage.
- * @param {String} filesGlob – Files match glob.
+ * Collects coverage data from the instrumented source.
+ * @param {String} filePath – Relative path of a file to collect from.
  * @param {Object} options – Command options.
- * @param {String} options.outFile – Destination file for coverage data.
- * @param {String} [options.formatter] – Coverage data formatter.
- * @return {undefined} Nothing is returned.
+ * @param {String} options.outFile – Destination file.
+ * @return {undefined}
  * @example
- *  # Take all .js files from "instrumented" folder, run them,
- *  # and write coverage data to "coverage.json" file:
- *  collectAction('instrumented/*.js', {outFile: 'coverage.json'});
+ *  # Run an instrumented foo.js file, collect coverage data,
+ *  # and write the result to "coverage.json" file:
+ *  collectAction('foo.js', {outFile: 'coverage.json'});
  */
-module.exports = function collectAction(filesGlob, options) {
-  var path = require('path');
-  var glob = require('glob');
+module.exports = function collectAction(filePath, options) {
   var chalk = require('chalk');
-  var write = require('../output-writer');
+  var writeToFile = require('../write-to-file');
+  var readFromStdin;
 
-  require('babel-register');
+  options = options || {};
 
-  glob(filesGlob, function (globErr, files) {
-    if (globErr) {
-      console.error(chalk.red('Failed to glob ' + filesGlob));
-      console.error(globErr);
-      process.exit(1);
-    }
-    files.forEach(function (file) {
-      require(path.resolve(file));
-    });
-  });
-
-  process.on('beforeExit', function () {
+  process.once('exit', function () {
     if (typeof __coverage__ !== 'object') {
       console.error(chalk.red('Failed to generate coverage.'));
       process.exit(1);
     }
-    write(__coverage__, options);
+
+    if (options.outFile) {
+      writeToFile(JSON.stringify(__coverage__), options.outFile);
+    } else {
+      process.stdout.write(JSON.stringify(__coverage__));
+    }
   });
+
+  if (filePath) {
+    require(filePath);
+  } else {
+    readFromStdin = require('../read-from-stdin');
+    readFromStdin(function readFromStdinCallback(code) {
+      module._compile(code, '');
+    });
+  }
 };

--- a/lib/help/collect.js
+++ b/lib/help/collect.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-template-curly-in-string */
+
+'use strict';
+
+/**
+ * Outputs help for the collect command.
+ * @return {undefined} Nothing is returned.
+ */
+module.exports = function outputInstrumentHelp() {
+  var chalk = require('chalk');
+  console.log([
+    '  Examples:\n',
+    chalk.dim('  Collect coverage from file and write output to stdout:'),
+    '  esnext-coverage collect instrumented.js\n',
+    chalk.dim('  Take instrumented code from stdin and write output to stdout:'),
+    '  cat instrumented.js | esnext-coverage collect\n',
+    chalk.dim('  Collect coverage from file and write output to a file in existing directory:'),
+    '  esnext-coverage collect instrumented.js > coverage.json\n',
+    chalk.dim('  Collect coverage from file and write output to a file in a new directory,'),
+    chalk.dim('  intermediate directories will be created as required (same as mkdir -p):'),
+    '  esnext-coverage collect instrumented.js -o a/b/c/coverage.json\n',
+    chalk.dim('  Collect coverage from multiple files:'),
+    '  for file in instrumented/**/*.js; do',
+    '    esnext-coverage collect "$file" -o ${file/js/json}',
+    '  done'
+  ].join('\n  '));
+};


### PR DESCRIPTION
Allows to chain `instrument | collect | format` actions.

Closes #8